### PR TITLE
IT-35944 / TargetSystemMappings added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 sourceSets {
   main {
     groovy {
-      srcDirs = ['vars']
+      srcDirs = ['vars','resources']
     }
   }
 }
@@ -31,6 +31,7 @@ dependencies {
 	compile group: 'javax.mail', name: 'mail', version: '1.4.1'
 	compile group: 'org.jenkins-ci.main', name: 'jenkins-core', version: '2.222'
 	compile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
+	testCompile group: 'org.spockframework' ,name: 'spock-core', version: '1.3-groovy-2.4'
 }
 
 publishing {

--- a/resources/targetSystemMappings.groovy
+++ b/resources/targetSystemMappings.groovy
@@ -1,0 +1,50 @@
+import groovy.json.JsonSlurper
+import org.springframework.util.Assert
+
+import java.nio.file.Files
+
+def static create(def tsmFilePath) {
+    File tsmFile = new File(tsmFilePath)
+    Assert.isTrue(Files.exists(tsmFile.toPath()),"${tsmFilePath} does not exist!!")
+    def tsmInstance = TargetSystemMappings.instance
+    tsmInstance.setTsmFile(tsmFile)
+    tsmInstance
+}
+
+@Singleton()
+class TargetSystemMappings {
+
+    private File tsmFile
+    def setTsmFile(def tsmFile){
+        this.tsmFile = tsmFile
+    }
+
+    def findStatus(String toStatus) {
+        //TODO JHE, not sure what we want here
+    }
+
+    def serviceTypeFor(String serviceName, String target) {
+        def targetInstances = loadTargetInstances(tsmFile.text)
+        return targetInstances."${target}".find{service -> service.name.equalsIgnoreCase(serviceName)}.type
+    }
+
+    def installTargetFor(String serviceName, String target) {
+        def targetInstances = loadTargetInstances(tsmFile.text)
+        return targetInstances."${target}".find{service -> service.name.equalsIgnoreCase(serviceName)}.host
+    }
+
+    def isLightInstance(String target) {
+        def targetInstances = loadTargetInstances(tsmFile.text)
+        // JHE (12.08.2020): For now, we check if "light" is in host name of the DB service
+        return targetInstances."${target}".find{service -> service.name.equalsIgnoreCase("it21-db")}.host.contains("light")
+    }
+
+    private def loadTargetInstances(targetSystemMappingAsText) {
+        def targetInstances = [:]
+        def targetSystemMappingAsJson = new JsonSlurper().parseText(targetSystemMappingAsText)
+        targetSystemMappingAsJson.targetInstances.each( {targetInstance ->
+            targetInstances.put(targetInstance.name,targetInstance.services)
+        })
+        targetInstances
+    }
+}

--- a/resources/targetSystemMappings.groovy
+++ b/resources/targetSystemMappings.groovy
@@ -51,6 +51,11 @@ class  TargetSystemMappings {
         vts
     }
 
+    def listInstallTargets() {
+        def targetSystemMappingAsJson = new JsonSlurper().parseText(tsmFile.text)
+        return targetSystemMappingAsJson.onDemandTarget
+    }
+
     private def loadStageMapping(targetSystemMappingAsText) {
         def stageMapping = [:]
         def targetSystemMappingAsJson = new JsonSlurper().parseText(targetSystemMappingAsText)

--- a/resources/targetSystemMappings.groovy
+++ b/resources/targetSystemMappings.groovy
@@ -12,7 +12,7 @@ def static create(def tsmFilePath) {
 }
 
 @Singleton()
-class TargetSystemMappings {
+class  TargetSystemMappings {
 
     private File tsmFile
     def setTsmFile(def tsmFile){
@@ -37,6 +37,27 @@ class TargetSystemMappings {
         def targetInstances = loadTargetInstances(tsmFile.text)
         // JHE (12.08.2020): For now, we check if "light" is in host name of the DB service
         return targetInstances."${target}".find{service -> service.name.equalsIgnoreCase("it21-db")}.host.contains("light")
+    }
+
+    def validToStates() {
+        def vts = []
+        def stageMapping = loadStageMapping(tsmFile.text)
+        stageMapping.keySet().each { stage ->
+            stageMapping.get(stage).each { toStage ->
+                // Ensure we store String, and not GString
+                vts.add((String)"${stage}${toStage.toState}")
+            }
+        }
+        vts
+    }
+
+    private def loadStageMapping(targetSystemMappingAsText) {
+        def stageMapping = [:]
+        def targetSystemMappingAsJson = new JsonSlurper().parseText(targetSystemMappingAsText)
+        targetSystemMappingAsJson.stageMappings.each( {stage ->
+            stageMapping.put(stage.name,stage.stages)
+        })
+        stageMapping
     }
 
     private def loadTargetInstances(targetSystemMappingAsText) {

--- a/resources/targetSystemMappings.groovy
+++ b/resources/targetSystemMappings.groovy
@@ -53,7 +53,10 @@ class  TargetSystemMappings {
 
     def listInstallTargets() {
         def targetSystemMappingAsJson = new JsonSlurper().parseText(tsmFile.text)
-        return targetSystemMappingAsJson.onDemandTarget
+        def odt = []
+        // Ensure we return a list of String, and not GString
+        targetSystemMappingAsJson.onDemandTarget.each{target -> odt.add((String)target)}
+        odt
     }
 
     private def loadStageMapping(targetSystemMappingAsText) {

--- a/resources/targetSystemMappings.groovy
+++ b/resources/targetSystemMappings.groovy
@@ -20,7 +20,15 @@ class  TargetSystemMappings {
     }
 
     def findStatus(String toStatus) {
-        //TODO JHE, not sure what we want here
+        def statusMap = [:]
+        def targetSystemMappingAsJson = new JsonSlurper().parseText(tsmFile.text)
+        targetSystemMappingAsJson.stageMappings.find({ a ->
+            a.stages.find({
+                def m = [:]
+                statusMap.put((String)"${a.name}${it.toState}",(String)"${it.code}")
+            })
+        })
+        return Integer.valueOf(statusMap."${toStatus}")
     }
 
     def serviceTypeFor(String serviceName, String target) {

--- a/resources/targetSystemMappings.groovy
+++ b/resources/targetSystemMappings.groovy
@@ -59,6 +59,22 @@ class  TargetSystemMappings {
         odt
     }
 
+    def stateMap() {
+        def stateMap = [:]
+        def targetSystemMappingAsJson = new JsonSlurper().parseText(tsmFile.text)
+        targetSystemMappingAsJson.stageMappings.find({ a ->
+            a.stages.find({
+                def m = [:]
+                m.put("targetName",(String)"${a.name}")
+                m.put("clsName",(String)"${it.implcls}")
+                m.put("stage",(String)"${it.name}")
+                m.put("target",(String)"${a.target}")
+                stateMap.put((String)"${a.name}${it.toState}",m)
+            })
+        })
+        stateMap
+    }
+
     private def loadStageMapping(targetSystemMappingAsText) {
         def stageMapping = [:]
         def targetSystemMappingAsJson = new JsonSlurper().parseText(targetSystemMappingAsText)

--- a/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
+++ b/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
@@ -64,4 +64,61 @@ class TargetSystemMappingGroovyImplTest extends Specification {
             lit.contains("test-CHTI212")
             lit.contains("test-devjhe")
     }
+
+    def "test stateMap"() {
+        when:
+            def stateMap = tsmObject.stateMap()
+        then:
+            stateMap != null
+            stateMap.size() == 8
+            def keys = stateMap.keySet()
+            keys.contains("Entwicklung")
+            keys.contains("Informatiktest")
+            keys.contains("Anwendertest")
+            keys.contains("Produktion")
+            keys.contains("EntwicklungInstallationsbereit")
+            keys.contains("InformatiktestInstallationsbereit")
+            keys.contains("AnwendertestInstallationsbereit")
+            keys.contains("ProduktionInstallationsbereit")
+            // Entwicklung entries
+            stateMap.get("Entwicklung").get("targetName").equals("Entwicklung")
+            stateMap.get("Entwicklung").get("clsName").equals("com.apgsga.microservice.patch.server.impl.PipelineInputAction")
+            stateMap.get("Entwicklung").get("stage").equals("cancel")
+            stateMap.get("Entwicklung").get("target").equals("test-CHEI212")
+            // Informatiktest entries
+            stateMap.get("Informatiktest").get("targetName").equals("Informatiktest")
+            stateMap.get("Informatiktest").get("clsName").equals("com.apgsga.microservice.patch.server.impl.PipelineInputAction")
+            stateMap.get("Informatiktest").get("stage").equals("InstallFor")
+            stateMap.get("Informatiktest").get("target").equals("test-CHEI211")
+            // Anwendertest entries
+            stateMap.get("Anwendertest").get("targetName").equals("Anwendertest")
+            stateMap.get("Anwendertest").get("clsName").equals("com.apgsga.microservice.patch.server.impl.PipelineInputAction")
+            stateMap.get("Anwendertest").get("stage").equals("InstallFor")
+            stateMap.get("Anwendertest").get("target").equals("test-CHTI211")
+            // Produktion entries
+            stateMap.get("Produktion").get("targetName").equals("Produktion")
+            stateMap.get("Produktion").get("clsName").equals("com.apgsga.microservice.patch.server.impl.PipelineInputAction")
+            stateMap.get("Produktion").get("stage").equals("InstallFor")
+            stateMap.get("Produktion").get("target").equals("test-CHPI211")
+            // EntwicklungInstallationsbereit entries
+            stateMap.get("EntwicklungInstallationsbereit").get("targetName").equals("Entwicklung")
+            stateMap.get("EntwicklungInstallationsbereit").get("clsName").equals("com.apgsga.microservice.patch.server.impl.EntwicklungInstallationsbereitAction")
+            stateMap.get("EntwicklungInstallationsbereit").get("stage").equals("startPipelineAndTag")
+            stateMap.get("EntwicklungInstallationsbereit").get("target").equals("test-CHEI212")
+            // InformatiktestInstallationsbereit entries
+            stateMap.get("InformatiktestInstallationsbereit").get("targetName").equals("Informatiktest")
+            stateMap.get("InformatiktestInstallationsbereit").get("clsName").equals("com.apgsga.microservice.patch.server.impl.PipelineInputAction")
+            stateMap.get("InformatiktestInstallationsbereit").get("stage").equals("BuildFor")
+            stateMap.get("InformatiktestInstallationsbereit").get("target").equals("test-CHEI211")
+            // AnwendertestInstallationsbereit entries
+            stateMap.get("AnwendertestInstallationsbereit").get("targetName").equals("Anwendertest")
+            stateMap.get("AnwendertestInstallationsbereit").get("clsName").equals("com.apgsga.microservice.patch.server.impl.PipelineInputAction")
+            stateMap.get("AnwendertestInstallationsbereit").get("stage").equals("BuildFor")
+            stateMap.get("AnwendertestInstallationsbereit").get("target").equals("test-CHTI211")
+            // ProduktionInstallationsbereit entries
+            stateMap.get("ProduktionInstallationsbereit").get("targetName").equals("Produktion")
+            stateMap.get("ProduktionInstallationsbereit").get("clsName").equals("com.apgsga.microservice.patch.server.impl.PipelineInputAction")
+            stateMap.get("ProduktionInstallationsbereit").get("stage").equals("BuildFor")
+            stateMap.get("ProduktionInstallationsbereit").get("target").equals("test-CHPI211")
+    }
 }

--- a/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
+++ b/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
@@ -30,12 +30,27 @@ class TargetSystemMappingGroovyImplTest extends Specification {
             guiServiceType == "test-service-chei211.apgsga.ch"
     }
 
-    def "isLightInstance"() {
+    def "test isLightInstance"() {
         when:
             def lightInstance = tsmObject.isLightInstance("test-dev-jhe")
             def nonLightInstance = tsmObject.isLightInstance("test-CHEI212")
         then:
             lightInstance == true
             nonLightInstance == false
+    }
+
+    def "test validToStates"() {
+        when:
+            def vts = tsmObject.validToStates()
+        then:
+            vts.size() == 8
+            vts.contains("Entwicklung")
+            vts.contains("Informatiktest")
+            vts.contains("Anwendertest")
+            vts.contains("Produktion")
+            vts.contains("EntwicklungInstallationsbereit")
+            vts.contains("InformatiktestInstallationsbereit")
+            vts.contains("AnwendertestInstallationsbereit")
+            vts.contains("ProduktionInstallationsbereit")
     }
 }

--- a/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
+++ b/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
@@ -1,0 +1,41 @@
+import spock.lang.Specification
+
+class TargetSystemMappingGroovyImplTest extends Specification {
+
+    def tsmClassFilePath = "resources/targetSystemMappings.groovy"
+    def tsmJson = "src/test/resources/TargetSystemMappings.json"
+    def tsmObject
+
+    def setup() {
+        def gs = new GroovyShell()
+        def script = gs.parse(new File(tsmClassFilePath))
+        tsmObject = script.create(tsmJson)
+    }
+
+    def "test serviceTypeFor"() {
+        when:
+            def linuxServiceType = tsmObject.serviceTypeFor("jadas","test-CHTI211")
+            def guiServiceType = tsmObject.serviceTypeFor("it21_ui","test-CHEI211")
+        then:
+            linuxServiceType.equals("linuxservice")
+            guiServiceType.equals("linuxbasedwindowsfilesystem")
+    }
+
+    def "test installTargetFor"() {
+        when:
+            def linuxServiceType = tsmObject.installTargetFor("jadas","test-CHTI211")
+            def guiServiceType = tsmObject.installTargetFor("it21_ui","test-CHEI211")
+        then:
+            linuxServiceType == "test-jadas-t.apgsga.ch"
+            guiServiceType == "test-service-chei211.apgsga.ch"
+    }
+
+    def "isLightInstance"() {
+        when:
+            def lightInstance = tsmObject.isLightInstance("test-dev-jhe")
+            def nonLightInstance = tsmObject.isLightInstance("test-CHEI212")
+        then:
+            lightInstance == true
+            nonLightInstance == false
+    }
+}

--- a/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
+++ b/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
@@ -53,4 +53,15 @@ class TargetSystemMappingGroovyImplTest extends Specification {
             vts.contains("AnwendertestInstallationsbereit")
             vts.contains("ProduktionInstallationsbereit")
     }
+
+    def "test listInstallTargets"() {
+        when:
+            def lit = tsmObject.listInstallTargets()
+        then:
+            lit.size() == 4
+            lit.contains("test-CHEI211")
+            lit.contains("test-CHEI212")
+            lit.contains("test-CHTI212")
+            lit.contains("test-devjhe")
+    }
 }

--- a/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
+++ b/src/test/groovy/TargetSystemMappingGroovyImplTest.groovy
@@ -121,4 +121,16 @@ class TargetSystemMappingGroovyImplTest extends Specification {
             stateMap.get("ProduktionInstallationsbereit").get("stage").equals("BuildFor")
             stateMap.get("ProduktionInstallationsbereit").get("target").equals("test-CHPI211")
     }
+
+    def "test findStatus"() {
+        expect:
+            tsmObject.findStatus("Entwicklung") == 0
+            tsmObject.findStatus("EntwicklungInstallationsbereit") == 2
+            tsmObject.findStatus("Informatiktest") == 20
+            tsmObject.findStatus("InformatiktestInstallationsbereit") == 15
+            tsmObject.findStatus("Anwendertest") == 30
+            tsmObject.findStatus("AnwendertestInstallationsbereit") == 25
+            tsmObject.findStatus("Produktion") == 80
+            tsmObject.findStatus("ProduktionInstallationsbereit") == 65
+    }
 }

--- a/src/test/resources/TargetSystemMappings.json
+++ b/src/test/resources/TargetSystemMappings.json
@@ -1,0 +1,264 @@
+{
+    "onDemandTarget": [
+        "test-CHEI211",
+        "test-CHEI212",
+        "test-CHTI212",
+        "test-devjhe"
+    ],
+    "stageMappings": [
+        {
+            "name": "Entwicklung",
+            "target": "test-CHEI212",
+	        "stages": [
+                {
+                    "name": "startPipelineAndTag",
+                    "toState": "Installationsbereit",
+                    "code": 2,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.EntwicklungInstallationsbereitAction"
+                },
+                {
+                    "name": "cancel",
+                    "toState": "",
+                    "code": 0,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                }
+            ]
+        },
+        {
+            "name": "Informatiktest",
+            "target": "test-CHEI211",
+            "stages": [
+                {
+                    "name": "BuildFor",
+                    "toState": "Installationsbereit",
+                    "code": 15,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                },
+                {
+                    "name": "InstallFor",
+                    "toState": "",
+                    "code": 20,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                }
+            ]
+        },
+        {
+            "name": "Anwendertest",
+            "target": "test-CHTI211",
+            "stages": [
+                {
+                    "name": "BuildFor",
+                    "toState": "Installationsbereit",
+                    "code": 25,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                },
+                {
+                    "name": "InstallFor",
+                    "toState": "",
+                    "code": 30,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                }
+            ]
+        },
+        {
+            "name": "Produktion",
+            "target": "test-CHPI211",
+            "stages": [
+                {
+                    "name": "BuildFor",
+                    "toState": "Installationsbereit",
+                    "code": 65,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                },
+                {
+                    "name": "InstallFor",
+                    "toState": "",
+                    "code": 80,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                }
+            ]
+        }
+    ],
+    "targetInstances": [
+        {
+            "name": "test-CHPI211",
+            "services": [
+                {
+                    "host": "test-chpi211.apgsga.ch",
+                    "name": "it21-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-ds.apgsga.ch",
+                    "name": "ds-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-digiflex-p.apgsga.ch",
+                    "name": "digiflex",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-jadas-p.apgsga.ch",
+                    "name": "jadas",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-service-chpi211.apgsga.ch",
+                    "name": "it21_ui",
+                    "type": "linuxbasedwindowsfilesystem"
+                }
+            ]
+        },
+        {
+            "name": "test-CHTI211",
+            "services": [
+                {
+                    "host": "test-chti211.apgsga.ch",
+                    "name": "it21-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-ds.apgsga.ch",
+                    "name": "ds-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-digiflex-t.apgsga.ch",
+                    "name": "digiflex",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-jadas-t.apgsga.ch",
+                    "name": "jadas",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-service-chti211.apgsga.ch",
+                    "name": "it21_ui",
+                    "type": "linuxbasedwindowsfilesystem"
+                }
+            ]
+        },
+        {
+            "name": "test-CHEI211",
+            "services": [
+                {
+                    "host": "test-chei211.apgsga.ch",
+                    "name": "it21-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-ds.apgsga.ch",
+                    "name": "ds-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-digiflex-e.apgsga.ch",
+                    "name": "digiflex",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-jadas-e.apgsga.ch",
+                    "name": "jadas",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-service-chei211.apgsga.ch",
+                    "name": "it21_ui",
+                    "type": "linuxbasedwindowsfilesystem"
+                }
+            ]
+        },
+        {
+            "name": "test-CHEI212",
+            "services": [
+                {
+                    "host": "test-chei212.apgsga.ch",
+                    "name": "it21-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-ds.apgsga.ch",
+                    "name": "ds-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-digiflex-e.apgsga.ch",
+                    "name": "digiflex",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-jadas-e.apgsga.ch",
+                    "name": "jadas",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-service-chei212.apgsga.ch",
+                    "name": "it21_ui",
+                    "type": "linuxbasedwindowsfilesystem"
+                }
+            ]
+        },
+        {
+            "name": "test-CHTI212",
+            "services": [
+                {
+                    "host": "test-chti212.apgsga.ch",
+                    "name": "it21-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-ds.apgsga.ch",
+                    "name": "ds-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-digiflex-t.apgsga.ch",
+                    "name": "digiflex",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-jadas-t.apgsga.ch",
+                    "name": "jadas",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-service-chti212.apgsga.ch",
+                    "name": "it21_ui",
+                    "type": "linuxbasedwindowsfilesystem"
+                }
+            ]
+        },
+        {
+            "name": "test-dev-jhe",
+            "services": [
+                {
+                    "host": "test-dev-jhe.light.apgsga.ch",
+                    "name": "it21-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-ds.apgsga.ch",
+                    "name": "ds-db",
+                    "type": "oracle-db"
+                },
+                {
+                    "host": "test-dev-jhe.light.apgsga.ch",
+                    "name": "digiflex",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-dev-jhedocker.light.apgsga.ch",
+                    "name": "jadas",
+                    "type": "linuxservice"
+                },
+                {
+                    "host": "test-dev-jhedocker.light.apgsga.ch",
+                    "name": "it21_ui",
+                    "type": "linuxbasedwindowsfilesystem"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
@chhex : a quick one to be merged here. Basically what we discussed on Thursday (13.08), and using now GroovyShell in the test class. 
"resources" folder added in order for the pipeline to use the build-in functionality to load a resource.
resources/targetSystemMappings.groovy will be the file retrieve from Github by Piper (pull request on corresponfing project will follow)
Obviously some new methods will be added based on requirement, the pull request is more regarding a validation of the structure.