### PR TITLE
use patch number as suffix for oracle target folder names

### DIFF
--- a/vars/assembleAndDeployPatchFunctions.groovy
+++ b/vars/assembleAndDeployPatchFunctions.groovy
@@ -75,7 +75,7 @@ def extractDbZips(parameter) {
                 commonPatchFunctions.log("Content of ${env.DBZIPS_FILE_PATH}/${dbZipName} zip will be use for final assembled ZIP.","extractDbZips")
                 unzip zipFile:"${env.DBZIPS_FILE_PATH}/${dbZipName}"
                 fileOperations([
-                        folderRenameOperation(source: "oracle", destination: "oracle_${String.format('%04d',i)}")
+                        folderRenameOperation(source: "oracle", destination: "oracle_${String.format('%04d',i)}_${patchNumber}")
                 ])
             }
         }


### PR DESCRIPTION
actually the problem is, that it is quite difficult to find the parts of a specific patch within the assembled db-package.